### PR TITLE
Load UI layout and adjust dwell calculations

### DIFF
--- a/src/scenes/Game.ts
+++ b/src/scenes/Game.ts
@@ -1,4 +1,5 @@
 import { Renderer } from '../ui/renderer'
+import type { UiLayout } from '../ui/renderer'
 import { Mulberry32 } from '../engine/rng'
 import { loadLine, loadJSON } from '../sim/line'
 import type { Tuning, Line, Train, Passenger, Station } from '../sim/types'
@@ -17,6 +18,7 @@ export class Game {
   private rng = new Mulberry32(1337)
   private tuning!: Tuning
   private line!: Line
+  private uiLayout!: UiLayout
   private trains: Train[] = []
   private passengers: Passenger[] = []
   private stationQueues: Map<number, Passenger[]> = new Map()
@@ -38,6 +40,7 @@ export class Game {
   private async init(){
     this.tuning = await loadJSON<Tuning>('/data/tuning.json')
     this.line = await loadLine()
+    this.uiLayout = await loadJSON<UiLayout>('/data/uiLayout.json')
     this.breakdownSystem = new BreakdownSystem(this.tuning, this.rng);
     this.delaySystem = new DelaySystem(this.tuning, this.rng);
 
@@ -137,8 +140,8 @@ export class Game {
     }
 
     // Check if an action button was clicked
-    if (this.selectedTrain) {
-      const actions = this.tuning.hud.actions;
+    if (this.selectedTrain && this.uiLayout) {
+      const actions = this.uiLayout.hud.actions;
       for (let i = 0; i < actions.order.length; i++) {
         const action = actions.order[i];
         const buttonX = this.canvas.width + actions.x - (actions.order.length - i) * (actions.buttonSize + actions.gap);

--- a/src/systems/boarding.ts
+++ b/src/systems/boarding.ts
@@ -1,10 +1,10 @@
 import type { Train, Station, Passenger, Tuning, Line } from '../sim/types';
 
-// TODO: Implement dwell formula and FIFO boarding/alighting.
-// dwellSec = clamp(min, base + perPax*(board+alight), max)
+// TODO: Implement FIFO boarding/alighting.
+// dwellSec = clamp(min, base + perPax*(board + alight*2), max)
 // Stop boarding if onboard > capacityCrush.
 export function computeDwellSeconds(board: number, alight: number, base: number, per: number, min: number, max: number){
-  const v = base + per*(board + alight)
+  const v = base + per * (board + alight * 2)
   return Math.max(min, Math.min(max, v))
 }
 

--- a/src/ui/renderer.ts
+++ b/src/ui/renderer.ts
@@ -2,7 +2,7 @@ import type { Train, Line } from '../sim/types';
 import { loadJSON } from '../sim/line';
 
 // TODO: move to a more appropriate place
-interface UiLayout {
+export interface UiLayout {
   colors: Record<string, string>;
   sprites: Record<string, { w: number, h: number, r: number }>;
   hud: {


### PR DESCRIPTION
## Summary
- export UiLayout from renderer and load layout in Game to drive action button handling
- tweak dwell formula to weight alighting passengers and clamp to min/max

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a867152a6c8321937e2fc45d6cb8b3